### PR TITLE
Rudia: Fix min power handling

### DIFF
--- a/src/main/java/de/thomas_oster/liblasercut/FloatMinMaxPowerSpeedFrequencyProperty.java
+++ b/src/main/java/de/thomas_oster/liblasercut/FloatMinMaxPowerSpeedFrequencyProperty.java
@@ -67,8 +67,10 @@ public class FloatMinMaxPowerSpeedFrequencyProperty extends FloatPowerSpeedFrequ
    */
   public void setMinPower(float power)
   {
+    power = power < 0 ? 0 : power;
+    power = power > 100 ? 100 : power;
     if (power > this.getPower()) { /* minimum must not be larger than maximum */
-      power = this.getPower();
+      this.setPower(power);	 /* increase max power, so that user can first enter min, then max power */
     }
     this.min_power = power;
   }

--- a/src/main/java/de/thomas_oster/liblasercut/drivers/Ruida.java
+++ b/src/main/java/de/thomas_oster/liblasercut/drivers/Ruida.java
@@ -1100,7 +1100,7 @@ class ByteStream
     }
     else {
       if (val > 16383) {
-        throw new IllegalArgumentException("Relative unsigned value > 16383");
+        throw new IllegalArgumentException("Relative unsigned value " + val + " > 16383");
       }
       else if (val < 0) {
         throw new IllegalArgumentException("Relative unsigned value < 0");
@@ -1127,8 +1127,8 @@ class ByteStream
    * append percent value
    */
   public ByteStream percent(int percent) throws IOException {
-    double val = (double)percent / 0.006103516; // 100/2^14
-//    System.out.println("percentValueToByteArray(" + percent + " -> " + val + ")");
+    double val = (double)percent / 0.0061038881767686; // 100/(2^14-1)
+    // System.out.println("percentValueToByteArray(" + percent + " -> " + val + ")");
     return relativeUnsigned(val);
   }
 

--- a/test-output/de.thomas_oster.liblasercut.drivers.Ruida.out
+++ b/test-output/de.thomas_oster.liblasercut.drivers.Ruida.out
@@ -1,1 +1,1 @@
-Ò›úâ‹p	ým{ý‰z‹‰Ò‰p‰‰‰‰‰‰‰‰‰‰p‰‰‰õ‰‰‰‰‰p‰‰é‰‰…ùpÙ‰‰‰õ‰‰‰‰‰pY‰‰é‰‰…ùp‰	‰	‰‰‰‰‰‰‰‰‰‰p‰Ä«‹pÛ‰‰‰‰õ‰‰‰‰‰p[‰‰‰é‰‰…ùpi‰‰‰‰õ‰‰‰‰‰pë‰‰‰é‰‰…ùÐ9‰‰‰Ð»‰‰‰B‰‰‰5ÉÐé‰‰‰‰‰ýÄ‰‰‰‰‰íÄI‰‰Ä	‰Ä‹‰Ä	B‹‰‰5ÉÐ	‰‰Ð‹‰‰ÄÄ™‰‚‰‰‰õ‰‰‰õ¢‰‰	Ï±‰‰…ù¢‰‰…ù‰‰‰‰‰‚‰‰é‰‰‰‰‰¢‰‰[/‰‰‰/Ñ¢‰‰Û}‰‰	—é"‰{"w±m"‰;/Ñ¢‰‰[/‰‰‹m‘¢‰‰é‰‰…ùpÛ	‰‰‰‰‰‰‡_p[	‰‰‰U‰‰‰™]pi	‰‰‰‰‰‰‡_pë	‰‰‰U‰‰‰™]Ð9	‰‰Ð»	‰‰B	‰‰5ÉÐé	‰‰‰‰ýÄ	‰‰‰‰íÄI	‹Ä		Ä‹	Ä	B‹‰‰5ÉÐ	‰‰Ð‹‰‰ÄÄ™‰‚‰‰‰‰‰‰‡_¢‰‰‰q‰‰‰‡_¢‰‰‰W‰‰‰‡_¢‰‰‰›‰‰‰‡_¢‰‰‰£‰‰‰‡_¢‰‰‰U‰‰‰‡_‚‰‰‰U‰‰‰ƒ¢‰‰‰£‰‰‰ƒ¢‰‰‰M‰‰‰ƒ¢‰‰‰W‰‰‰ƒ¢‰‰‰¥‰‰‰ƒ¢‰‰‰‰‰‰ƒ‚‰‰‰‰‰‰5¢‰‰‰U‰‰‰5‚‰‰‰U‰‰‰ù¢‰‰‰q‰‰‰ù¢‰‰‰‰‰‰ù‚‰‰‰‰‰‰™«¢‰‰‰U‰‰‰™«‚‰‰‰U‰‰‰™]¢‰‰‰q‰‰‰™]¢‰‰‰‰‰‰™]pÛ‹‰‰‰™]‰‰‰—Op[‹‰‰‰—‰‰‰©Mpi‹‰‰‰™]‰‰‰—Opë‹‰‰‰—‰‰‰©MÐ9‹‰‰Ð»‹‰‰B‹‰‰5ÉÐé‹‰‰‰‰ýÄ‹‰‰‰‰íÄI‹‹Ä		Ä‹‹Ä	B‹‰‰5ÉÐ	‰‰Ð‹‰‰ÄÄ™‰‚‰‰‰3‰‰‰—O¢‰‰‰›©‰‰‰—O‚‰‰‰›[‰‰‰—O¢‰‰‰å‰‰‰—O‚‰‰‰å‰‰‰—ó¢‰‰‰‰‰‰—ó‚‰‰‰›©‰‰‰—ó¢‰‰‰e‰‰‰—ó‚‰‰‰™]‰‰‰%¢‰‰‰‰‰‰%‚‰‰‰3‰‰‰%¢‰‰‰—‰‰‰%‚‰‰‰—‰‰‰é¢‰‰‰3‰‰‰é‚‰‰‰™]‰‰‰©M¢‰‰‰3‰‰‰©MÔ	©‰‰‰‹e‰‰‰‹ep‰`
+Ò›úâ‹p	ým{ý‰z‹‰Ò‰p‰‰‰‰‰‰‰‰‰‰p‰‰‰õ‰‰‰‰‰p‰‰é‰‰…ùpÙ‰‰‰õ‰‰‰‰‰pY‰‰é‰‰…ùp‰	‰	‰‰‰‰‰‰‰‰‰‰p‰Ä«‹pÛ‰‰‰‰õ‰‰‰‰‰p[‰‰‰é‰‰…ùpi‰‰‰‰õ‰‰‰‰‰pë‰‰‰é‰‰…ùÐ9‰wwÐ»‰wwB‰‰‰5ÉÐé‰‰‰‰‰ýÄ‰‰‰‰‰íÄI‰‰Ä	‰Ä‹‰Ä	B‹‰‰5ÉÐ	wwÐ‹wwÄÄ™‰‚‰‰‰õ‰‰‰õ¢‰‰	Ï±‰‰…ù¢‰‰…ù‰‰‰‰‰‚‰‰é‰‰‰‰‰¢‰‰[/‰‰‰/Ñ¢‰‰Û}‰‰	—é"‰{"w±m"‰;/Ñ¢‰‰[/‰‰‹m‘¢‰‰é‰‰…ùpÛ	‰‰‰‰‰‰‡_p[	‰‰‰U‰‰‰™]pi	‰‰‰‰‰‰‡_pë	‰‰‰U‰‰‰™]Ð9	wwÐ»	wwB	‰‰5ÉÐé	‰‰‰‰ýÄ	‰‰‰‰íÄI	‹Ä		Ä‹	Ä	B‹‰‰5ÉÐ	wwÐ‹wwÄÄ™‰‚‰‰‰‰‰‰‡_¢‰‰‰q‰‰‰‡_¢‰‰‰W‰‰‰‡_¢‰‰‰›‰‰‰‡_¢‰‰‰£‰‰‰‡_¢‰‰‰U‰‰‰‡_‚‰‰‰U‰‰‰ƒ¢‰‰‰£‰‰‰ƒ¢‰‰‰M‰‰‰ƒ¢‰‰‰W‰‰‰ƒ¢‰‰‰¥‰‰‰ƒ¢‰‰‰‰‰‰ƒ‚‰‰‰‰‰‰5¢‰‰‰U‰‰‰5‚‰‰‰U‰‰‰ù¢‰‰‰q‰‰‰ù¢‰‰‰‰‰‰ù‚‰‰‰‰‰‰™«¢‰‰‰U‰‰‰™«‚‰‰‰U‰‰‰™]¢‰‰‰q‰‰‰™]¢‰‰‰‰‰‰™]pÛ‹‰‰‰™]‰‰‰—Op[‹‰‰‰—‰‰‰©Mpi‹‰‰‰™]‰‰‰—Opë‹‰‰‰—‰‰‰©MÐ9‹wwÐ»‹wwB‹‰‰5ÉÐé‹‰‰‰‰ýÄ‹‰‰‰‰íÄI‹‹Ä		Ä‹‹Ä	B‹‰‰5ÉÐ	wwÐ‹wwÄÄ™‰‚‰‰‰3‰‰‰—O¢‰‰‰›©‰‰‰—O‚‰‰‰›[‰‰‰—O¢‰‰‰å‰‰‰—O‚‰‰‰å‰‰‰—ó¢‰‰‰‰‰‰—ó‚‰‰‰›©‰‰‰—ó¢‰‰‰e‰‰‰—ó‚‰‰‰™]‰‰‰%Ð‹Ww¢‰‰‰‰‰‰%‚‰‰‰3‰‰‰%¢‰‰‰—‰‰‰%‚‰‰‰—‰‰‰éÐ‹É‰¢‰‰‰3‰‰‰é‚‰‰‰™]‰‰‰©MÐ‹ww¢‰‰‰3‰‰‰©MÔ	©‰‰‰‹e‰‰‰‹ep‰`


### PR DESCRIPTION
This PR is also sent upstream as https://github.com/t-oster/LibLaserCut/pull/199

----

This PR fixes a few issues related to min power. FloatMinMaxPowerSpeedFrequencyProperty.java and Ruida.java

* We now prevent min_power < 0 and > 100, which was previously accepted in the UI.
* Due to off-by-one scaling in percent(), min_power = 100 caused an exception IllegalArgumentException: Relative unsigned value 16384 > 16383
* When entering new power and speed settings in the UI, power is initially 0. User wants to enter values from left to right. first min power, then power, then speed. Min power was reset to 0 immediately after entering. This is now fixed by raising max power to match min power (instead of lowering min_power to match the (not yet entered) max power.
* The test file resulted in all 0% values due to the above issue, instead of producing the intended 50, 75, 100% values. The expected test output is updated:

$ ruida_decode LibLaserCut/test-output/de.thomas_oster.liblasercut.drivers.Ruida.out | grep Pow
```
Laser_1_Min_Pow_C6_31 Layer:0 0%			c6 31 00 00 00
Laser_1_Max_Pow_C6_32 Layer:0 0%			c6 32 00 00 00
Laser_1_Min_Pow_C6_01 0%				c6 01 00 00
Laser_1_Max_Pow_C6_02 0%				c6 02 00 00
Laser_1_Min_Pow_C6_31 Layer:1 0%			c6 31 01 00 00
Laser_1_Max_Pow_C6_32 Layer:1 0%			c6 32 01 00 00
Laser_1_Min_Pow_C6_01 0%				c6 01 00 00
Laser_1_Max_Pow_C6_02 0%				c6 02 00 00
Laser_1_Min_Pow_C6_31 Layer:2 0%			c6 31 02 00 00
Laser_1_Max_Pow_C6_32 Layer:2 0%			c6 32 02 00 00
Laser_1_Min_Pow_C6_01 0%				c6 01 00 00
Laser_1_Max_Pow_C6_02 0%				c6 02 00 00
```
$ ruida_decode LibLaserCut/test-output/de.thomas_oster.liblasercut.drivers.Ruida.out.new | grep Pow
```
Laser_1_Min_Pow_C6_31 Layer:0 100%			c6 31 00 7f 7f
Laser_1_Max_Pow_C6_32 Layer:0 100%			c6 32 00 7f 7f
Laser_1_Min_Pow_C6_01 100%				c6 01 7f 7f
Laser_1_Max_Pow_C6_02 100%				c6 02 7f 7f
Laser_1_Min_Pow_C6_31 Layer:1 100%			c6 31 01 7f 7f
Laser_1_Max_Pow_C6_32 Layer:1 100%			c6 32 01 7f 7f
Laser_1_Min_Pow_C6_01 100%				c6 01 7f 7f
Laser_1_Max_Pow_C6_02 100%				c6 02 7f 7f
Laser_1_Min_Pow_C6_31 Layer:2 100%			c6 31 02 7f 7f
Laser_1_Max_Pow_C6_32 Layer:2 100%			c6 32 02 7f 7f
Laser_1_Min_Pow_C6_01 100%				c6 01 7f 7f
Laser_1_Max_Pow_C6_02 100%				c6 02 7f 7f
Laser_1_Max_Pow_C6_02 75%				c6 02 5f 7f
Laser_1_Max_Pow_C6_02 50%				c6 02 40 00
Laser_1_Max_Pow_C6_02 100%				c6 02 7f 7f
```
